### PR TITLE
feat: render dependencies with React Flow

### DIFF
--- a/src/config/project_config.rs
+++ b/src/config/project_config.rs
@@ -1,6 +1,9 @@
+use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
-use std::path::{Path, PathBuf};
-use anyhow::{Result, Context};
+use std::{
+    fmt,
+    path::{Path, PathBuf},
+};
 
 /// Available themes
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -147,26 +150,29 @@ impl ProjectConfig {
         let path = path.as_ref();
         let content = std::fs::read_to_string(path)
             .with_context(|| format!("Failed to read config file: {}", path.display()))?;
-        
-        let extension = path.extension()
+
+        let extension = path
+            .extension()
             .and_then(|ext| ext.to_str())
             .unwrap_or("toml");
-        
+
         match extension {
-            "toml" => toml::from_str(&content)
-                .with_context(|| "Failed to parse TOML config"),
-            "yaml" | "yml" => serde_yaml::from_str(&content)
-                .with_context(|| "Failed to parse YAML config"),
-            "json" => serde_json::from_str(&content)
-                .with_context(|| "Failed to parse JSON config"),
-            _ => Err(anyhow::anyhow!("Unsupported config file format: {}", extension)),
+            "toml" => toml::from_str(&content).with_context(|| "Failed to parse TOML config"),
+            "yaml" | "yml" => {
+                serde_yaml::from_str(&content).with_context(|| "Failed to parse YAML config")
+            }
+            "json" => serde_json::from_str(&content).with_context(|| "Failed to parse JSON config"),
+            _ => Err(anyhow::anyhow!(
+                "Unsupported config file format: {}",
+                extension
+            )),
         }
     }
-    
+
     /// Load configuration from a project directory
     pub fn from_project_dir<P: AsRef<Path>>(dir: P) -> Result<Self> {
         let dir = dir.as_ref();
-        
+
         // Look for config files in the directory
         for config_file in crate::config::CONFIG_FILES {
             let path = dir.join(config_file);
@@ -174,27 +180,26 @@ impl ProjectConfig {
                 return Self::from_file(&path);
             }
         }
-        
+
         // If no config file found, try to load from Cargo.toml
         let cargo_toml = dir.join("Cargo.toml");
         if cargo_toml.exists() {
             return Self::from_cargo_toml(&cargo_toml);
         }
-        
+
         // Return default config
         Ok(Self::default())
     }
-    
+
     /// Load configuration from Cargo.toml
     pub fn from_cargo_toml<P: AsRef<Path>>(path: P) -> Result<Self> {
-        let content = std::fs::read_to_string(path)
-            .with_context(|| "Failed to read Cargo.toml")?;
-        
-        let cargo_config: CargoConfig = toml::from_str(&content)
-            .with_context(|| "Failed to parse Cargo.toml")?;
-        
+        let content = std::fs::read_to_string(path).with_context(|| "Failed to read Cargo.toml")?;
+
+        let cargo_config: CargoConfig =
+            toml::from_str(&content).with_context(|| "Failed to parse Cargo.toml")?;
+
         let mut config = Self::default();
-        
+
         if let Some(package) = cargo_config.package {
             config.project.name = Some(package.name);
             config.project.description = package.description;
@@ -202,28 +207,40 @@ impl ProjectConfig {
             config.project.authors = package.authors.unwrap_or_default();
             config.project.repository = package.repository;
         }
-        
+
         Ok(config)
     }
-    
+
     /// Save configuration to a file
     pub fn save_to_file<P: AsRef<Path>>(&self, path: P) -> Result<()> {
         let path = path.as_ref();
-        let content = match path.extension()
-            .and_then(|ext| ext.to_str()) {
-            Some("toml") => toml::to_string_pretty(self)
-                .with_context(|| "Failed to serialize TOML config")?,
-            Some("yaml") | Some("yml") => serde_yaml::to_string(self)
-                .with_context(|| "Failed to serialize YAML config")?,
-            Some("json") => serde_json::to_string_pretty(self)
-                .with_context(|| "Failed to serialize JSON config")?,
-            _ => return Err(anyhow::anyhow!("Unsupported config file format")),
-        };
-        
+        let content =
+            match path.extension().and_then(|ext| ext.to_str()) {
+                Some("toml") => toml::to_string_pretty(self)
+                    .with_context(|| "Failed to serialize TOML config")?,
+                Some("yaml") | Some("yml") => serde_yaml::to_string(self)
+                    .with_context(|| "Failed to serialize YAML config")?,
+                Some("json") => serde_json::to_string_pretty(self)
+                    .with_context(|| "Failed to serialize JSON config")?,
+                _ => return Err(anyhow::anyhow!("Unsupported config file format")),
+            };
+
         std::fs::write(path, content)
             .with_context(|| format!("Failed to write config file: {}", path.display()))?;
-        
+
         Ok(())
+    }
+}
+
+impl fmt::Display for LayoutType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            LayoutType::Grid => write!(f, "grid"),
+            LayoutType::ForceDirected => write!(f, "force"),
+            LayoutType::Hierarchical => write!(f, "hierarchical"),
+            LayoutType::Circular => write!(f, "circular"),
+            LayoutType::Custom(value) => write!(f, "{}", value),
+        }
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,6 @@
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use chrono::{DateTime, Utc};
 
 /// Represents a module in the architecture
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -99,6 +99,31 @@ impl ModuleType {
             ModuleType::Logging => "📝",
             ModuleType::Monitoring => "📈",
             ModuleType::Other(_) => "📦",
+        }
+    }
+
+    /// Human-friendly display name for the module type
+    pub fn display_name(&self) -> String {
+        match self {
+            ModuleType::Core => "Core".to_string(),
+            ModuleType::DataProcessing => "Data Processing".to_string(),
+            ModuleType::AI => "AI".to_string(),
+            ModuleType::Performance => "Performance".to_string(),
+            ModuleType::Validation => "Validation".to_string(),
+            ModuleType::Execution => "Execution".to_string(),
+            ModuleType::Integration => "Integration".to_string(),
+            ModuleType::API => "API".to_string(),
+            ModuleType::Processing => "Processing".to_string(),
+            ModuleType::Scaffold => "Scaffold".to_string(),
+            ModuleType::Testing => "Testing".to_string(),
+            ModuleType::Utilities => "Utilities".to_string(),
+            ModuleType::Configuration => "Configuration".to_string(),
+            ModuleType::Database => "Database".to_string(),
+            ModuleType::Network => "Network".to_string(),
+            ModuleType::Security => "Security".to_string(),
+            ModuleType::Logging => "Logging".to_string(),
+            ModuleType::Monitoring => "Monitoring".to_string(),
+            ModuleType::Other(label) => label.clone(),
         }
     }
 }
@@ -236,4 +261,4 @@ pub struct ArchitectureMetrics {
 pub use crate::config::project_config::VisualizationSettings;
 
 // Re-export Theme and LayoutType from config
-pub use crate::config::project_config::{Theme, LayoutType};
+pub use crate::config::project_config::{LayoutType, Theme};


### PR DESCRIPTION
## Summary
- expose a `display_name` for `ModuleType` and add a `Display` implementation for `LayoutType`
- generate React Flow node/edge data from the scanned architecture instead of emitting placeholder SVG lines
- embed React Flow via CDN with new CSS/JS to render an interactive dependency graph and update the details panel

## Testing
- `cargo test` *(fails: existing examples refer to non-re-exported config types; see compiler errors)*

------
https://chatgpt.com/codex/tasks/task_e_68caa152f7288327ada6288e493715ac